### PR TITLE
Adds a peer dependency on React

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "react-native-drawer-layout": "2.0.0"
   },
   "peerDependencies": {
-    "react-native": ">= 0.35"
+    "react-native": ">= 0.35",
+    "react": "*"
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",


### PR DESCRIPTION
The `react-native-drawer-layout` package has peer dependencies on `react`, which means that `react-native-drawer-layout-polyfill` also depends on it.